### PR TITLE
req LocalDictionaryDataSource/LocalFileDataSource

### DIFF
--- a/lib/configcat.rb
+++ b/lib/configcat.rb
@@ -1,4 +1,6 @@
 require 'configcat/interfaces'
+require 'configcat/localdictionarydatasource'
+require 'configcat/localfiledatasource'
 require 'configcat/configcatclient'
 require 'configcat/user'
 require 'logger'

--- a/spec/configcat_spec.rb
+++ b/spec/configcat_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe ConfigCat do
   it "has a version number" do
     expect(ConfigCat::VERSION).not_to be nil
   end
+
+  it "exposes ConfigCat::LocalDictionaryDataSource" do
+    expect(ConfigCat::LocalDictionaryDataSource).not_to be nil
+  end
+
+  it "exposes ConfigCat::LocalFileDataSource" do
+    expect(ConfigCat::LocalFileDataSource).not_to be nil
+  end
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

To expose ConfigCat::LocalFileDataSource and ConfigCat::LocalDictionaryDataSource to be used by consumers.

The Docs [over here](https://configcat.com/docs/sdk-reference/ruby/#json-file) and [here](https://configcat.com/docs/sdk-reference/ruby/#hash) document usage of these classes but they're not available after requiring the `configcat` gem.

Added two require statements to the top of the `lib/configcat.rb` file and two specs to make sure that the classes are available.

### Related issues (only if applicable)

(Have not reported issue)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
