### PR TITLE
ConfigEntry empty etag

### DIFF
--- a/lib/configcat/configentry.rb
+++ b/lib/configcat/configentry.rb
@@ -35,6 +35,6 @@ module ConfigCat
       }
     end
 
-    EMPTY = ConfigEntry.new
+    EMPTY = ConfigEntry.new(etag: 'empty')
   end
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

Use `empty` etag string for empty config entry

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
