### PR TITLE
Fix wrong return value of get_value_details() in case config JSON is not present

### DIFF
--- a/lib/configcat/configcatclient.rb
+++ b/lib/configcat/configcatclient.rb
@@ -126,8 +126,9 @@ module ConfigCat
       if settings.nil?
         message = "Config JSON is not present when evaluating setting '#{key}'. Returning the `default_value` parameter that you specified in your application: '#{default_value}'."
         @log.error(1000, message)
-        @hooks.invoke_on_flag_evaluated(EvaluationDetails.from_error(key, default_value, error: message))
-        return default_value
+        details = EvaluationDetails.from_error(key, default_value, error: message)
+        @hooks.invoke_on_flag_evaluated(details)
+        return details
       end
       details = _evaluate(key, user, default_value, nil, settings, fetch_time)
       return details


### PR DESCRIPTION
### Describe the purpose of your pull request

- get_value_details() returns an `EvaluationDetails` object in case config JSON is not present

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
