### PR TITLE
Fix initial config load when auto poll enabled with results from cache

### DIFF
--- a/lib/configcat/version.rb
+++ b/lib/configcat/version.rb
@@ -1,3 +1,3 @@
 module ConfigCat
-  VERSION = "8.0.0"
+  VERSION = "8.0.1"
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix initial config JSON load when auto poll enabled with results from cache.

### Related issues (only if applicable)

https://trello.com/c/sDEMAHdS/398-auto-poll-fix

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
