### PR TITLE
fix: make it so logger level works with integers or symbols

### DIFF
--- a/lib/configcat/configcatlogger.rb
+++ b/lib/configcat/configcatlogger.rb
@@ -5,7 +5,7 @@ module ConfigCat
     end
 
     def enabled_for?(log_level)
-      ConfigCat.logger.level <= log_level
+      ::Logger::Severity.coerce(ConfigCat.logger.level) <= log_level
     end
 
     def debug(message)

--- a/lib/configcat/configcatlogger.rb
+++ b/lib/configcat/configcatlogger.rb
@@ -24,5 +24,27 @@ module ConfigCat
       @hooks.invoke_on_error(message)
       ConfigCat.logger.error("[" + event_id.to_s + "] " + message)
     end
+    private
+
+    def coerce_log_level(level)
+      return level if level.is_a?(Integer)
+
+      case level.to_s.downcase
+      when 'trace', 'debug'
+        ::Logger::DEBUG
+      when 'info'
+        ::Logger::INFO
+      when 'warn'
+        ::Logger::WARN
+      when 'error'
+        ::Logger::ERROR
+      when 'fatal'
+        ::Logger::FATAL
+      when 'unknown'
+        ::Logger::UNKNOWN
+      else
+        raise ArgumentError, "invalid log level: #{level}"
+      end
+    end
   end
 end

--- a/lib/configcat/configcatlogger.rb
+++ b/lib/configcat/configcatlogger.rb
@@ -5,7 +5,7 @@ module ConfigCat
     end
 
     def enabled_for?(log_level)
-      ::Logger::Severity.coerce(ConfigCat.logger.level) <= log_level
+      coerce_log_level(ConfigCat.logger.level) <= log_level
     end
 
     def debug(message)

--- a/spec/configcat/configcat_logger_spec.rb
+++ b/spec/configcat/configcat_logger_spec.rb
@@ -1,21 +1,22 @@
 require 'spec_helper'
 
 RSpec.describe ConfigCat::ConfigCatLogger do
-  let(:subject) { described_class.new(nil) }
+  let(:logger) { double("logger") }
+  let(:configcat_logger) { described_class.new(nil) }
 
   before do
-    ConfigCat.logger = subject
+    allow(ConfigCat).to receive(:logger).and_return(logger)
   end
 
   describe "#enabled_for?" do
     it "works when logger level returns an integer" do
-      allow(subject).to receive(:level).and_return(2)
-      expect(subject.enabled_for?(::Logger::Severity::WARN)).to eq true
+      allow(logger).to receive(:level).and_return(2)
+      expect(configcat_logger.enabled_for?(::Logger::Severity::WARN)).to eq true
     end
 
     it "works when logger level returns a symbol" do
-      allow(subject).to receive(:level).and_return(:warn)
-      expect(subject.enabled_for?(::Logger::Severity::WARN)).to eq true
+      allow(logger).to receive(:level).and_return(:warn)
+      expect(configcat_logger.enabled_for?(::Logger::Severity::WARN)).to eq true
     end
   end
 end

--- a/spec/configcat/configcat_logger_spec.rb
+++ b/spec/configcat/configcat_logger_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe ConfigCat::ConfigCatLogger do
+  let(:subject) { described_class.new(nil) }
+
+  before do
+    ConfigCat.logger = subject
+  end
+
+  describe "#enabled_for?" do
+    it "works when logger level returns an integer" do
+      allow(subject).to receive(:level).and_return(2)
+      expect(subject.enabled_for?(::Logger::Severity::WARN)).to eq true
+    end
+
+    it "works when logger level returns a symbol" do
+      allow(subject).to receive(:level).and_return(:warn)
+      expect(subject.enabled_for?(::Logger::Severity::WARN)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Logger.level returns an integer. SemanticLogger.level returns a symbol.

Trying to use SemanticLogger with ConfigCatLogger broke as it was trying to do an integer level comparison.

This fixes that by coercing the level to ensure it's an integer.

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
